### PR TITLE
Use ExUnit.CLIFormatter only when extra_formatters are not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ require("neotest").setup({
     require("neotest-elixir")({
       -- Other formatters to pass to the test command as the formatters are overridden
       -- Can be a function to return a dynamic value.
-      extra_formatters = {"ExUnitNotifier"},
+      -- Default: {"ExUnit.CLIFormatter"}
+      extra_formatters = {"ExUnit.CLIFormatter", "ExUnitNotifier"}
       -- Can be Jason or Poison, default: Jason
       json_module = "Jason"
     }),

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -6,12 +6,15 @@ local base = require("neotest-elixir.base")
 ---@type neotest.Adapter
 local ElixirNeotestAdapter = { name = "neotest-elixir" }
 
-local default_formatters = { "ExUnit.CLIFormatter", "NeotestElixirFormatter" }
+local default_formatters = { "NeotestElixirFormatter" }
 
 local function get_formatters()
-  local formatters = default_formatters
+  -- tables need to be copied by value
+  local formatters = { unpack(default_formatters) }
   if ElixirNeotestAdapter.extra_formatters then
     vim.list_extend(formatters, ElixirNeotestAdapter.extra_formatters())
+  else
+    vim.list_extend(formatters, { "ExUnit.CLIFormatter" })
   end
 
   local result = {}


### PR DESCRIPTION
Hey 👋🏼! Thanks for the work on the elixir adapter. 

I work on a project where we cannot use `ExUnit.CLIFormatter` due to certain issues. We use a custom formatter instead. I think it's more a sensible default to not include `ExUnit.CLIFormatter` when `extra_formatters` are provided (as one can add `ExUnit.CLIFormatter` as an extra formatter anyways)