### PR TITLE
change position id to work for dynamic tests

### DIFF
--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -52,6 +52,23 @@ local function script_path()
   return str:match("(.*/)")
 end
 
+local function mix_root(file_path)
+  return lib.files.match_root_pattern("mix.exs")(file_path)
+end
+
+local function get_relative_path(file_path)
+  local mix_root_path = mix_root(file_path)
+  local root_elems = vim.split(mix_root_path, Path.path.sep)
+  local elems = vim.split(file_path, Path.path.sep)
+  return table.concat({unpack(elems, (#root_elems + 1), #elems)}, Path.path.sep)
+end
+
+local function generate_id(position)
+  local relative_path = get_relative_path(position.path)
+  local line_num = (position.range[1] + 1)
+  return (relative_path .. ":" .. line_num)
+end
+
 local exunit_formatter = (Path.new(script_path()):parent():parent() / "neotest_elixir/neotest_formatter.exs").filename
 
 ElixirNeotestAdapter.root = lib.files.match_root_pattern("mix.exs")
@@ -79,7 +96,7 @@ function ElixirNeotestAdapter.discover_positions(path)
   ) @test.definition
   ]]
 
-  return lib.treesitter.parse_positions(path, query, { nested_namespaces = false })
+  return lib.treesitter.parse_positions(path, query, { nested_namespaces = false, position_id = generate_id })
 end
 
 ---@async
@@ -152,11 +169,14 @@ function ElixirNeotestAdapter.results(spec, result)
 
     for _, line in ipairs(data) do
       local decoded_result = vim.json.decode(line, { luanil = { object = true } })
-      results[decoded_result.id] = {
-        status = decoded_result.status,
-        output = decoded_result.output,
-        errors = decoded_result.errors,
-      }
+      local earlier_result = results[decoded_result.id]
+      if (earlier_result == nil or earlier_result.status ~= "failed") then
+        results[decoded_result.id] = {
+          status = decoded_result.status,
+          output = decoded_result.output,
+          errors = decoded_result.errors,
+        }
+      end
     end
   else
     results[spec.context.position.id] = {

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -141,11 +141,14 @@ function ElixirNeotestAdapter.build_spec(args)
         local results = {}
         for _, line in ipairs(lines) do
           local decoded_result = vim.json.decode(line, { luanil = { object = true } })
-          results[decoded_result.id] = {
-            status = decoded_result.status,
-            output = decoded_result.output,
-            errors = decoded_result.errors,
-          }
+          local earlier_result = results[decoded_result.id]
+          if (earlier_result == nil or earlier_result.status ~= "failed") then
+            results[decoded_result.id] = {
+              status = decoded_result.status,
+              output = decoded_result.output,
+              errors = decoded_result.errors,
+            }
+          end
         end
         return results
       end

--- a/neotest_elixir/neotest_formatter.exs
+++ b/neotest_elixir/neotest_formatter.exs
@@ -75,19 +75,6 @@ defmodule NeotestElixirFormatter do
     "#{Path.relative_to_cwd(tags[:file])}:#{tags[:line]}"
   end
 
-  defp remove_prefix(%ExUnit.Test{} = test) do
-    name = to_string(test.name)
-
-    prefix =
-      if test.tags.describe do
-        "#{test.tags.test_type} #{test.tags.describe} "
-      else
-        "#{test.tags.test_type} "
-      end
-
-    String.replace_prefix(name, prefix, "")
-  end
-
   defp make_status(%ExUnit.Test{state: nil}), do: "passed"
   defp make_status(%ExUnit.Test{state: {:failed, _}}), do: "failed"
   defp make_status(%ExUnit.Test{state: {:skipped, _}}), do: "skipped"
@@ -99,7 +86,13 @@ defmodule NeotestElixirFormatter do
 
     if output do
       file = Path.join(config.output_dir, "test_output_#{:erlang.phash2(id)}")
-      File.write!(file, output, [:append])
+
+      if File.exists?(file) do
+        File.write!(file, ["\n\n", output], [:append])
+      else
+        File.write!(file, output)
+      end
+
       file
     end
   end

--- a/neotest_elixir/neotest_formatter.exs
+++ b/neotest_elixir/neotest_formatter.exs
@@ -33,10 +33,12 @@ defmodule NeotestElixirFormatter do
         |> update_test_counter()
         |> update_failure_counter(test)
 
+      id = make_id(test)
+
       output = %{
-        id: make_id(test),
+        id: id,
         status: make_status(test),
-        output: save_test_output(test, config),
+        output: save_test_output(test, config, id),
         errors: make_errors(test)
       }
 
@@ -69,15 +71,8 @@ defmodule NeotestElixirFormatter do
 
   defp update_failure_counter(config, %ExUnit.Test{}), do: config
 
-  defp make_id(%ExUnit.Test{} = test) do
-    file = test.tags.file
-    name = remove_prefix(test)
-
-    if describe = test.tags.describe do
-      "#{file}::#{describe}::#{name}"
-    else
-      "#{file}::#{name}"
-    end
+  defp make_id(%ExUnit.Test{tags: tags} = _test) do
+    "#{Path.relative_to_cwd(tags[:file])}:#{tags[:line]}"
   end
 
   defp remove_prefix(%ExUnit.Test{} = test) do
@@ -99,12 +94,12 @@ defmodule NeotestElixirFormatter do
   defp make_status(%ExUnit.Test{state: {:excluded, _}}), do: "skipped"
   defp make_status(%ExUnit.Test{state: {:invalid, _}}), do: "failed"
 
-  defp save_test_output(%ExUnit.Test{} = test, config) do
+  defp save_test_output(%ExUnit.Test{} = test, config, id) do
     output = make_output(test, config)
 
     if output do
-      file = Path.join(config.output_dir, "test_output_#{config.test_counter}")
-      File.write!(file, output)
+      file = Path.join(config.output_dir, "test_output_#{:erlang.phash2(id)}")
+      File.write!(file, output, [:append])
       file
     end
   end


### PR DESCRIPTION
* changes id to {{rel_test_file_path}}:{{test_position}}
* appends file write for multiple errors within a single dynamic test
* updates status for dynamic tests considering all individual statuses