### PR TITLE
make root directory more specific

### DIFF
--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -54,7 +54,13 @@ end
 
 local exunit_formatter = (Path.new(script_path()):parent():parent() / "neotest_elixir/neotest_formatter.exs").filename
 
-ElixirNeotestAdapter.root = lib.files.match_root_pattern("mix.exs")
+function ElixirNeotestAdapter.root(file_path) 
+  local mix_root = lib.files.match_root_pattern("mix.exs")(file_path)
+  if mix_root==nil or mix_root == "" then
+    return mix_root
+  end
+  return mix_root .. Path.path.sep .. "test"
+end
 
 function ElixirNeotestAdapter.is_test_file(file_path)
   return base.is_test_file(file_path)


### PR DESCRIPTION
When the entire suite is run, the `is_test_file` is called for a lot of files outside the `test`, like `_build` and other unnecessary files. This leads to a very high CPU utilization at the start of the run of a suite. 
As per [mix docs](https://hexdocs.pm/mix/1.14.0-rc.1/Mix.Tasks.Test.html), the default pattern is `test/**/*_test.exs`. So in the PR, I've made the root as `test` dir within mix root. 
NOTE: If the suite is run with some test file loaded in a buffer, neotest still does some "discovery" causing `is_test_file` to be called for *all* files(To be more precise, even then there's a lesser number of calls to `is_test_file`, since there're duplicate calls). There's an [issue](https://github.com/nvim-neotest/neotest/issues/13) that seems to be about addressing this.
 But if the suite is run without any test file loaded on buffer, we can clearly see calls to `is_test_file` from only those within `test` directory