### PR TITLE
use :delayed_write option to reduce number of event triggers

### DIFF
--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -2,6 +2,7 @@ local Path = require("plenary.path")
 local async = require("neotest.async")
 local lib = require("neotest.lib")
 local base = require("neotest-elixir.base")
+local logger = require('neotest.logging')
 
 ---@type neotest.Adapter
 local ElixirNeotestAdapter = { name = "neotest-elixir" }
@@ -121,6 +122,7 @@ function ElixirNeotestAdapter.build_spec(args)
   local output_dir = async.fn.tempname()
   Path:new(output_dir):mkdir()
   local results_path = output_dir .. "/results"
+  logger.debug("result path: " .. results_path)
   local x = io.open(results_path, "w")
   x:write("")
   x:close()

--- a/neotest_elixir/neotest_formatter.exs
+++ b/neotest_elixir/neotest_formatter.exs
@@ -11,7 +11,7 @@ defmodule NeotestElixirFormatter do
     output_dir = System.fetch_env!("NEOTEST_OUTPUT_DIR")
     File.mkdir_p!(output_dir)
     results_path = Path.join(output_dir, "results")
-    results_io_device = File.open!(results_path, [:write, :utf8])
+    results_io_device = File.open!(results_path, [:write, :delayed_write, :utf8])
 
     config = %{
       output_dir: output_dir,


### PR DESCRIPTION
Currently each write is flushed, and so the number of result events triggered are numerous. This affects the responsivenes of neovim greatly when running the entire test suite on large projects. Using the `:delayed_write` option ([doc](https://www.erlang.org/doc/man/file.html#open-2)) improves this greatly.
Obviously with streaming this will reduce the live update a bit, but it's not very noticeable IMO. 
The `size` and `delay` values are configurable. Sticking to default right now (as per docs it's 64kb, 2 seconds)

### Before the change
<img width="717" alt="Screenshot 2022-09-08 at 19 06 00" src="https://user-images.githubusercontent.com/59688988/189136338-46b6111e-e0ca-493d-850f-b1bbd3c93533.png">

### After the change

<img width="717" alt="Screenshot 2022-09-08 at 19 04 53" src="https://user-images.githubusercontent.com/59688988/189136521-df607b9c-5615-4c27-81d0-72f6138dc22d.png">