### PR TITLE
feat: Embed a JSON encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ use({
 })
 ```
 
-## Caveats
-
-Currently, the adapter requires either Jason or Poison to be available in the project
-
 ## Configuration
 
 You can optionally specify some settings:
@@ -44,8 +40,6 @@ require("neotest").setup({
       -- Can be a function that receives the position, to return a dynamic value
       -- Default: {}
       args = {"--trace"},
-      -- Can be Jason or Poison, default: Jason
-      json_module = "Jason"
     }),
   }
 })
@@ -61,7 +55,7 @@ require("neotest").run.run({vim.fn.expand("%"), extra_args = {"--formatter", "Ex
 
 - [X] Store output in temp files directly from the ExUnit formatter
 - [X] Enable colors
-- [ ] Support projects without a JSON library in the dependencies
+- [X] Support projects without a JSON library in the dependencies
 - [X] Handle dynamic tests like when you have for a loop that generates tests
 - [X] Show error in line with diagnostics
 - [X] Allow specifying extra formatters

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -7,7 +7,7 @@ local logger = require("neotest.logging")
 ---@type neotest.Adapter
 local ElixirNeotestAdapter = { name = "neotest-elixir" }
 
-local default_formatters = { "NeotestElixirFormatter" }
+local default_formatters = { "NeotestElixir.Formatter" }
 
 local function get_extra_formatters()
   return { "ExUnit.CLIFormatter" }

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -136,7 +136,6 @@ function ElixirNeotestAdapter.build_spec(args)
   x:close()
 
   local stream_data, stop_stream = lib.files.stream_lines(results_path)
-  local json_module = ElixirNeotestAdapter.json_module or "Jason"
 
   return {
     command = command,
@@ -165,7 +164,6 @@ function ElixirNeotestAdapter.build_spec(args)
     end,
     env = {
       NEOTEST_OUTPUT_DIR = output_dir,
-      NEOTEST_JSON_MODULE = json_module,
     },
   }
 end
@@ -222,8 +220,6 @@ setmetatable(ElixirNeotestAdapter, {
         return opts.args
       end
     end
-
-    ElixirNeotestAdapter.json_module = opts.json_module
 
     return ElixirNeotestAdapter
   end,

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -74,6 +74,7 @@ local function generate_id(position)
   return (relative_path .. ":" .. line_num)
 end
 
+local json_encoder = (Path.new(script_path()):parent():parent() / "neotest_elixir/json_encoder.exs").filename
 local exunit_formatter = (Path.new(script_path()):parent():parent() / "neotest_elixir/neotest_formatter.exs").filename
 
 ElixirNeotestAdapter.root = lib.files.match_root_pattern("mix.exs")
@@ -112,6 +113,8 @@ function ElixirNeotestAdapter.build_spec(args)
   local command = vim.tbl_flatten({
     {
       "elixir",
+      "-r",
+      json_encoder,
       "-r",
       exunit_formatter,
       "-S",

--- a/neotest_elixir/json_encoder.exs
+++ b/neotest_elixir/json_encoder.exs
@@ -1,4 +1,11 @@
 defmodule NeotestElixir.JsonEncoder do
+  @moduledoc """
+  A custom JSON encoder that doesn't use protocols based on [elixir-json](https://github.com/cblage/elixir-json).
+
+  The encoder is embedded because that way we don't depend on a library being installed
+  in the project and also we can't really add dependencies ourselves.
+  """
+
   @acii_space 32
 
   def encode!(input) do

--- a/neotest_elixir/json_encoder.exs
+++ b/neotest_elixir/json_encoder.exs
@@ -1,0 +1,82 @@
+defmodule NeotestElixir.JsonEncoder do
+  @acii_space 32
+
+  def encode!(input) do
+    do_encode(input)
+  end
+
+  defp do_encode(number) when is_number(number), do: to_string(number)
+  defp do_encode(nil), do: "null"
+  defp do_encode(true), do: "true"
+  defp do_encode(false), do: "false"
+  defp do_encode(atom) when is_atom(atom), do: do_encode(to_string(atom))
+
+  defp do_encode(string) when is_binary(string) do
+    [?", Enum.reverse(encode_binary(string, [])), ?"]
+  end
+
+  defp do_encode(map) when is_map(map) do
+    content =
+      Enum.map(map, fn {key, value} ->
+        [do_encode(key), ": ", do_encode(value)]
+      end)
+
+    [?{, Enum.intersperse(content, ", "), ?}]
+  end
+
+  defp do_encode(list) when is_list(list) do
+    content = Enum.map(list, &do_encode/1)
+
+    [?[, Enum.intersperse(content, ", "), ?]]
+  end
+
+  defp encode_binary(<<>>, acc) do
+    acc
+  end
+
+  defp encode_binary(<<head::utf8, tail::binary>>, acc) do
+    encode_binary(tail, [encode_binary_character(head) | acc])
+  end
+
+  defp encode_binary_character(?"), do: [?\\, ?"]
+  defp encode_binary_character(?\b), do: [?\\, ?b]
+  defp encode_binary_character(?\f), do: [?\\, ?f]
+  defp encode_binary_character(?\n), do: [?\\, ?n]
+  defp encode_binary_character(?\r), do: [?\\, ?r]
+  defp encode_binary_character(?\t), do: [?\\, ?t]
+  defp encode_binary_character(?\\), do: [?\\, ?\\]
+
+  defp encode_binary_character(char) when is_number(char) and char < @acii_space do
+    [?\\, ?u | encode_hexadecimal_unicode_control_character(char)]
+  end
+
+  defp encode_binary_character(char), do: char
+
+  defp encode_hexadecimal_unicode_control_character(char) when is_number(char) do
+    char
+    |> Integer.to_charlist(16)
+    |> zeropad_hexadecimal_unicode_control_character()
+  end
+
+  defp zeropad_hexadecimal_unicode_control_character([a, b, c]), do: [?0, a, b, c]
+  defp zeropad_hexadecimal_unicode_control_character([a, b]), do: [?0, ?0, a, b]
+  defp zeropad_hexadecimal_unicode_control_character([a]), do: [?0, ?0, ?0, a]
+  defp zeropad_hexadecimal_unicode_control_character(iolist) when is_list(iolist), do: iolist
+end
+
+# NeotestElixir.JsonEncoder.encode!(%{
+#   a: 1,
+#   b: nil,
+#   c: true,
+#   d: false,
+#   e: :cool,
+#   f: "some string",
+#   g: [1, 2.0, "three"],
+#   h: %{
+#     "i" => "nested",
+#     "j" => "map"
+#   },
+#   l: "some string with a \t and a \n",
+#   m: "\0\3\a"
+# })
+# |> IO.puts()

--- a/neotest_elixir/neotest_formatter.exs
+++ b/neotest_elixir/neotest_formatter.exs
@@ -1,4 +1,4 @@
-defmodule NeotestElixirFormatter do
+defmodule NeotestElixir.Formatter do
   @moduledoc """
   A custom ExUnit formatter to provide output that is easier to parse.
   """

--- a/neotest_elixir/neotest_formatter.exs
+++ b/neotest_elixir/neotest_formatter.exs
@@ -6,6 +6,8 @@ defmodule NeotestElixir.Formatter do
 
   require Logger
 
+  alias NeotestElixir.JsonEncoder
+
   @impl true
   def init(opts) do
     output_dir = System.fetch_env!("NEOTEST_OUTPUT_DIR")
@@ -42,7 +44,7 @@ defmodule NeotestElixir.Formatter do
         errors: make_errors(test)
       }
 
-      IO.puts(config.results_io_device, json_encode!(output))
+      IO.puts(config.results_io_device, JsonEncoder.encode!(output))
 
       {:noreply, config}
     catch
@@ -237,22 +239,5 @@ defmodule NeotestElixir.Formatter do
     @default_colors
     |> Keyword.merge(opts[:colors])
     |> Keyword.put_new(:enabled, IO.ANSI.enabled?())
-  end
-
-  case System.get_env("NEOTEST_JSON_MODULE", "Jason") do
-    "Jason" ->
-      def json_encode!(data) do
-        Jason.encode_to_iodata!(data)
-      end
-
-    "Poison" ->
-      def json_encode!(data) do
-        Poison.encode!(data, iodata: true)
-      end
-
-    "embedded" ->
-      def json_encode!(data) do
-        NeotestElixir.JsonEncoder.encode!(data)
-      end
   end
 end

--- a/neotest_elixir/neotest_formatter.exs
+++ b/neotest_elixir/neotest_formatter.exs
@@ -249,5 +249,10 @@ defmodule NeotestElixirFormatter do
       def json_encode!(data) do
         Poison.encode!(data, iodata: true)
       end
+
+    "embedded" ->
+      def json_encode!(data) do
+        NeotestElixir.JsonEncoder.encode!(data)
+      end
   end
 end


### PR DESCRIPTION
Adds a custom implementation of a JSON encoder. Doesn't use protocols, as consolidating takes a lot of time.

This way we don't care if a project has a JSON library available.

Closes #4 