### PR TITLE
Add optional command wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ require("neotest").setup({
       -- Can be a function that receives the position, to return a dynamic value
       -- Default: {}
       args = {"--trace"},
+      -- Command wrapper
+      -- Can be a function that receives the mix command as a table, to return a dynamic value
+      -- Default: function() return function(cmd) return cmd end end
+      post_process_cmd = function()
+        return function(cmd)
+          local newcmd = cmd
+          table.insert(newcmd, 1, 'env')
+          table.insert(newcmd, 2, 'MIX_ENV=foo')
+          return cmd
+        end
+      end,
       -- Delays writes so that results are updated at most every given milliseconds
       -- Decreasing this number improves snappiness at the cost of performance
       -- Can be a function to return a dynamic value.

--- a/README.md
+++ b/README.md
@@ -45,15 +45,10 @@ require("neotest").setup({
       -- Default: {}
       args = {"--trace"},
       -- Command wrapper
-      -- Can be a function that receives the mix command as a table, to return a dynamic value
-      -- Default: function() return function(cmd) return cmd end end
-      post_process_cmd = function()
-        return function(cmd)
-          local newcmd = cmd
-          table.insert(newcmd, 1, 'env')
-          table.insert(newcmd, 2, 'MIX_ENV=foo')
-          return cmd
-        end
+      -- Must be a function that receives the mix command as a table, to return a dynamic value
+      -- Default: function(cmd) return cmd end
+      post_process_command = function(cmd)
+        return vim.tbl_flatten({"env", "FOO=bar"}, cmd})
       end,
       -- Delays writes so that results are updated at most every given milliseconds
       -- Decreasing this number improves snappiness at the cost of performance

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -60,7 +60,7 @@ local function get_mix_task()
   return "test"
 end
 
-local function get_post_process_command(cmd)
+local function post_process_command(cmd)
   return cmd
 end
 
@@ -254,8 +254,8 @@ function ElixirNeotestAdapter.build_spec(args)
     args.extra_args or {},
     get_args_from_position(position),
   })
-  local post_processed_command = get_post_process_command(command)
 
+  local post_processed_command = post_process_command(command)
   local output_dir = async.fn.tempname()
   Path:new(output_dir):mkdir()
   local results_path = output_dir .. "/results"
@@ -348,9 +348,8 @@ end
 
 setmetatable(ElixirNeotestAdapter, {
   __call = function(_, opts)
-    local post_process_command = callable_opt(opts.post_process_command)
-    if post_process_command then
-      get_post_process_command = post_process_command()
+    if opts.post_process_command and type(opts.post_process_command) == "function" then
+      post_process_command = opts.post_process_command
     end
 
     local mix_task = callable_opt(opts.mix_task)

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -108,10 +108,10 @@ ElixirNeotestAdapter.root = lib.files.match_root_pattern("mix.exs")
 
 function ElixirNeotestAdapter.filter_dir(_, rel_path, _)
   return rel_path == "test"
-      or vim.startswith(rel_path, "test/")
-      or rel_path == "apps"
-      or rel_path:match("^apps/[^/]+$")
-      or rel_path:match("^apps/[^/]+/test")
+    or vim.startswith(rel_path, "test/")
+    or rel_path == "apps"
+    or rel_path:match("^apps/[^/]+$")
+    or rel_path:match("^apps/[^/]+/test")
 end
 
 function ElixirNeotestAdapter.is_test_file(file_path)


### PR DESCRIPTION
This allows mangling the Mix command at runtime, useful when env vars have to be set before running Mix, or some other
manipulation is required. I am using this to set environment variables to dynamic values based on `docker ps` output. 
