### PR TITLE
Support for running tests in the IEx shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ luac.out
 *.x86_64
 *.hex
 
+# LS
+.lexical

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "neotest_elixir/iex-unit"]
+	path = neotest_elixir/iex-unit
+	url = https://github.com/scottming/iex-unit

--- a/lua/neotest-elixir/core.lua
+++ b/lua/neotest-elixir/core.lua
@@ -1,0 +1,217 @@
+local lib = require("neotest.lib")
+local Path = require("plenary.path")
+
+local M = {}
+
+local function relative_to_cwd(path)
+  local root = lib.files.match_root_pattern("mix.exs")(path)
+  return Path:new(path):make_relative(root)
+end
+
+-- Build the command to send to the IEx shell for running the test
+function M.build_iex_test_command(position, output_dir, seed, relative_to)
+  if not relative_to then
+    relative_to = relative_to_cwd
+  end
+  local relative_path = relative_to(position.path)
+
+  local function get_line_number()
+    if position.type == "test" then
+      return position.range[1] + 1
+    end
+  end
+
+  local line_number = get_line_number()
+  if line_number then
+    return string.format(
+      "IExUnit.run(%q, line: %s, seed: %s, output_dir: %q)",
+      relative_path,
+      line_number,
+      seed,
+      output_dir
+    )
+  else
+    return string.format("IExUnit.run(%q, seed: %s, output_dir: %q)", position.path, seed, output_dir)
+  end
+end
+
+function M.iex_watch_command(results_path, maybe_compile_error_path, seed)
+  -- the `&& cat maybe_compile_error_path` just for the case where encountering a compile error
+  return string.format(
+    "(tail -n 50 -f %s %s &) | grep -q %s && cat %s",
+    results_path,
+    maybe_compile_error_path,
+    seed,
+    maybe_compile_error_path
+  )
+end
+
+local function build_formatters(extra_formatters)
+  -- tables need to be copied by value
+  local default_formatters = { "NeotestElixir.Formatter" }
+  local formatters = { unpack(default_formatters) }
+  vim.list_extend(formatters, extra_formatters)
+
+  local result = {}
+  for _, formatter in ipairs(formatters) do
+    table.insert(result, "--formatter")
+    table.insert(result, formatter)
+  end
+
+  return result
+end
+
+---@param position neotest.Position
+---@return string[]
+local function test_target(position, relative_to)
+  -- Dependency injection for testing
+  if not relative_to then
+    relative_to = relative_to_cwd
+  end
+
+  local relative_path = relative_to(position.path)
+
+  if position.type == "test" then
+    local line = position.range[1] + 1
+    return { relative_path .. ":" .. line }
+  else
+    return { relative_path }
+  end
+end
+
+local function script_path()
+  local str = debug.getinfo(2, "S").source:sub(2)
+  return str:match("(.*/)")
+end
+
+M.plugin_path = Path.new(script_path()):parent():parent()
+
+-- TODO: dirty version -- make it public only for testing
+M.json_encoder_path = (M.plugin_path / "neotest_elixir/json_encoder.ex").filename
+M.exunit_formatter_path = (M.plugin_path / "neotest_elixir/formatter.ex").filename
+local mix_interactive_runner_path = (M.plugin_path / "neotest_elixir/test_interactive_runner.ex").filename
+
+local function options_for_task(mix_task)
+  if mix_task == "test.interactive" then
+    return {
+      "-r",
+      mix_interactive_runner_path,
+      "-e",
+      "Application.put_env(:mix_test_interactive, :runner, NeotestElixir.TestInteractiveRunner)",
+    }
+  else
+    return {
+      "-r",
+      M.json_encoder_path,
+      "-r",
+      M.exunit_formatter_path,
+    }
+  end
+end
+
+function M.build_mix_command(
+  position,
+  mix_task_func,
+  extra_formatters_func,
+  mix_task_args_func,
+  neotest_args,
+  relative_to_func
+)
+  return vim.tbl_flatten({
+    {
+      "elixir",
+    },
+    -- deferent tasks have different options
+    -- for example, `test.interactive` needs to load a custom runner
+    options_for_task(mix_task_func()),
+    {
+      "-S",
+      "mix",
+      mix_task_func(), -- `test` is default
+    },
+    -- default is ExUnit.CLIFormatter
+    build_formatters(extra_formatters_func()),
+    -- default is {}
+    -- maybe `test.interactive` has different args with `test`
+    mix_task_args_func(),
+    neotest_args.extra_args or {},
+    -- test file or directory or testfile:line
+    test_target(position, relative_to_func),
+  })
+end
+
+-- public only for testing
+function M.iex_start_command(opened_filename)
+  local filepath = opened_filename or vim.fn.expand("%:p")
+  local function is_in_umbrella_project()
+    return string.find(filepath, "/apps/") ~= nil
+  end
+
+  local function child_app_root_dir()
+    local umbrella_root = string.match(filepath, "(.*/apps/)"):sub(1, -7)
+    local child_root = string.match(filepath, "(.*/apps/[%w_]+)")
+    return Path:new(child_root):make_relative(umbrella_root)
+  end
+
+  -- generate a starting command for the iex terminal
+  local runner_path = (M.plugin_path / "neotest_elixir/iex-unit/lib/iex_unit.ex").filename
+  local start_code = "IExUnit.start()"
+  local configuration_code = "ExUnit.configure(formatters: [NeotestElixir.Formatter, ExUnit.CLIFormatter])"
+  local start_command = string.format(
+    "MIX_ENV=test iex --no-pry -S mix run -r %q -r %q -r %q -e %q -e %q",
+    M.json_encoder_path,
+    M.exunit_formatter_path,
+    runner_path,
+    start_code,
+    configuration_code
+  )
+
+  if not is_in_umbrella_project() then
+    return start_command
+  end
+
+  local function ends_with(cwd, relatived)
+    local relatived_len = string.len(relatived)
+    return string.sub(cwd, -relatived_len) == relatived
+  end
+
+  local child_root_relatived = child_app_root_dir()
+  if not ends_with(vim.fn.getcwd(), child_root_relatived) then
+    return string.format("cd %s && %s", child_root_relatived, start_command)
+  else
+    return start_command
+  end
+end
+
+function M.get_or_create_iex_term(id, direction_func)
+  local ok, toggleterm = pcall(require, "toggleterm")
+  if not ok then
+    vim.notify("Please install `toggleterm.nvim` first", vim.log.levels.ERROR)
+  end
+
+  local toggleterm_terminal = require("toggleterm.terminal")
+  local term = toggleterm_terminal.get(id)
+
+  if term == nil then
+    toggleterm.exec(M.iex_start_command(), id, nil, nil, "horizontal")
+    term = toggleterm_terminal.get_or_create_term(id)
+    return term
+  else
+    return term
+  end
+end
+
+function M.generate_seed()
+  local seed_str, _ = string.gsub(vim.fn.reltimestr(vim.fn.reltime()), "(%d+).(%d+)", "%1%2")
+  return tonumber(seed_str)
+end
+
+function M.create_and_clear(path)
+  local x = io.open(path, "w")
+  if x then
+    x:write("")
+    x:close()
+  end
+end
+
+return M

--- a/lua/neotest-elixir/core.lua
+++ b/lua/neotest-elixir/core.lua
@@ -158,7 +158,7 @@ function M.iex_start_command(opened_filename)
   local start_code = "IExUnit.start()"
   local configuration_code = "ExUnit.configure(formatters: [NeotestElixir.Formatter, ExUnit.CLIFormatter])"
   local start_command = string.format(
-    "MIX_ENV=test iex --no-pry -S mix run -r %q -r %q -r %q -e %q -e %q",
+    "MIX_ENV=test iex -S mix run -r %q -r %q -r %q -e %q -e %q",
     M.json_encoder_path,
     M.exunit_formatter_path,
     runner_path,

--- a/lua/neotest-elixir/core.lua
+++ b/lua/neotest-elixir/core.lua
@@ -191,9 +191,10 @@ function M.get_or_create_iex_term(id, direction_func)
 
   local toggleterm_terminal = require("toggleterm.terminal")
   local term = toggleterm_terminal.get(id)
+  local direction = direction_func and direction_func()
 
   if term == nil then
-    toggleterm.exec(M.iex_start_command(), id, nil, nil, "horizontal")
+    toggleterm.exec(M.iex_start_command(), id, nil, nil, direction)
     term = toggleterm_terminal.get_or_create_term(id)
     return term
   else

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -24,6 +24,10 @@ local function get_mix_task()
   return "test"
 end
 
+local function get_iex_shell_direction()
+  return "horizontal"
+end
+
 local function post_process_command(cmd)
   return cmd
 end
@@ -187,7 +191,7 @@ function ElixirNeotestAdapter.build_spec(args)
   local post_processing_command
   if args.strategy == "iex" then
     local MAGIC_IEX_TERM_ID = 42
-    local term = core.get_or_create_iex_term(MAGIC_IEX_TERM_ID)
+    local term = core.get_or_create_iex_term(MAGIC_IEX_TERM_ID, get_iex_shell_direction)
     local seed = core.generate_seed()
     local test_command = core.build_iex_test_command(position, output_dir, seed)
     term:send(test_command, true)
@@ -287,6 +291,11 @@ setmetatable(ElixirNeotestAdapter, {
     local mix_task = callable_opt(opts.mix_task)
     if mix_task then
       get_mix_task = mix_task
+    end
+
+    local iex_shell_direction = callable_opt(opts.iex_shell_direction)
+    if iex_shell_direction then
+      get_iex_shell_direction = iex_shell_direction
     end
 
     local extra_formatters = callable_opt(opts.extra_formatters)

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -1,5 +1,10 @@
+local ok, async = pcall(require, "nio")
+if not ok then
+  print("use plenary")
+  async = require("neotest.async")
+end
+
 local Path = require("plenary.path")
-local async = require("neotest.async")
 local lib = require("neotest.lib")
 local base = require("neotest-elixir.base")
 local core = require("neotest-elixir.core")

--- a/lua/neotest/client/strategies/iex/init.lua
+++ b/lua/neotest/client/strategies/iex/init.lua
@@ -1,0 +1,2 @@
+local iex = require("neotest.client.strategies.integrated")
+return iex

--- a/neotest_elixir/formatter.ex
+++ b/neotest_elixir/formatter.ex
@@ -10,16 +10,16 @@ defmodule NeotestElixir.Formatter do
 
   @impl true
   def init(opts) do
-    output_dir = System.fetch_env!("NEOTEST_OUTPUT_DIR")
+    output_dir = opts[:output_dir] || System.fetch_env!("NEOTEST_OUTPUT_DIR")
     File.mkdir_p!(output_dir)
     results_path = Path.join(output_dir, "results")
-
-    write_delay = String.to_integer(System.fetch_env!("NEOTEST_WRITE_DELAY"))
+    write_delay = String.to_integer(System.get_env("NEOTEST_WRITE_DELAY") || "100")
 
     results_io_device =
       File.open!(results_path, [:append, {:delayed_write, 64 * 1000, write_delay}, :utf8])
 
     config = %{
+      seed: opts[:seed],
       output_dir: output_dir,
       results_path: results_path,
       results_io_device: results_io_device,
@@ -49,6 +49,7 @@ defmodule NeotestElixir.Formatter do
       id = get_test_config(test, config).id
 
       output = %{
+        seed: config[:seed],
         id: id,
         status: make_status(test),
         output: save_test_output(test, config),

--- a/neotest_elixir/formatter.ex
+++ b/neotest_elixir/formatter.ex
@@ -155,7 +155,7 @@ defmodule NeotestElixir.Formatter do
   defp make_status(%ExUnit.Test{state: {:invalid, _}}), do: "failed"
 
   defp save_test_output(%ExUnit.Test{} = test, config) do
-    output = make_output(test, config)
+    output = [make_output(test, config), "\n"]
 
     if output do
       file = get_test_config(test, config).output_file

--- a/tests/unit/core_spec.lua
+++ b/tests/unit/core_spec.lua
@@ -1,0 +1,148 @@
+local core = require("neotest-elixir.core")
+
+describe("build_iex_test_command", function()
+  local relative_to
+
+  before_each(function()
+    -- always return the input
+    relative_to = function(path)
+      return path
+    end
+  end)
+
+  it("should return the correct command for a test", function()
+    local position = {
+      type = "test",
+      path = "example_test.exs",
+      range = { 1, 2 },
+    }
+    local output_dir = "test_output"
+    local seed = 1234
+
+    local actual = core.build_iex_test_command(position, output_dir, seed, relative_to)
+
+    assert.are.equal('IExUnit.run("example_test.exs", line: 2, seed: 1234, output_dir: "test_output")', actual)
+  end)
+
+  it("should return the correct command for a file", function()
+    local position = {
+      type = "file",
+      path = "test/neotest_elixir/core_spec.exs",
+      range = { 1, 2 },
+    }
+    local output_dir = "test_output"
+    local seed = 1234
+
+    local actual = core.build_iex_test_command(position, output_dir, seed, relative_to)
+
+    assert.are.equal('IExUnit.run("test/neotest_elixir/core_spec.exs", seed: 1234, output_dir: "test_output")', actual)
+  end)
+
+  it("should return the correct command for the folder", function()
+    local position = {
+      type = "folder",
+      path = "test/neotest_elixir",
+      range = { 1, 2 },
+    }
+    local output_dir = "test_output"
+    local seed = 1234
+
+    local actual = core.build_iex_test_command(position, output_dir, seed, relative_to)
+
+    assert.are.equal('IExUnit.run("test/neotest_elixir", seed: 1234, output_dir: "test_output")', actual)
+  end)
+end)
+
+describe("iex_watch_command", function()
+  it("should return the correct command", function()
+    local results_path = "results_path"
+    local maybe_compile_error_path = "maybe_compile_error_path"
+    local seed = 1234
+
+    local actual = core.iex_watch_command(results_path, maybe_compile_error_path, seed)
+
+    assert.are.equal(
+      "(tail -n 50 -f results_path maybe_compile_error_path &) | grep -q 1234 && cat maybe_compile_error_path",
+      actual
+    )
+  end)
+end)
+
+describe("get_or_create_iex_term", function()
+  local function starts_with(str, start)
+    return str:sub(1, #start) == start
+  end
+
+  it("should create a new iex term if none exists", function()
+    local actual = core.get_or_create_iex_term(42)
+    assert.are.equal(42, actual.id)
+  end)
+
+  it("should cd to the child app if the opened_file in umbrella project", function()
+    local actual = core.iex_start_command("/root/apps/child_app1/test/child_app_test.exs")
+    assert.is.True(starts_with(actual, "cd apps/child_app1 && "))
+  end)
+
+  it("should not cd to the some place when in a normal app", function()
+    local actual = core.iex_start_command("/root/my_app/test/my_app_test.exs")
+    assert.is.False(starts_with(actual, "iex -S mix"))
+  end)
+end)
+
+describe("build_mix_command", function()
+  local mix_task_func
+  local extra_formatter_func
+  local mix_task_args_func
+  local relative_to
+
+  before_each(function()
+    mix_task_func = function()
+      return "test"
+    end
+    extra_formatter_func = function()
+      return { "ExUnit.CLIFormatter" }
+    end
+    mix_task_args_func = function()
+      return {}
+    end
+    relative_to = function(path)
+      return path
+    end
+  end)
+
+  it("should return the correct command for a test", function()
+    local position = {
+      type = "test",
+      path = "example_test.exs",
+      range = { 1, 2 },
+    }
+
+    local actual_tbl =
+      core.build_mix_command(position, mix_task_func, extra_formatter_func, mix_task_args_func, {}, relative_to)
+
+    local expected = string.format(
+      "elixir -r %s -r %s -S mix test --formatter NeotestElixir.Formatter --formatter ExUnit.CLIFormatter example_test.exs:2",
+      core.json_encoder_path,
+      core.exunit_formatter_path
+    )
+    assert.are.equal(expected, table.concat(actual_tbl, " "))
+  end)
+
+  it("should not return line args for a file test", function()
+    local position = {
+      type = "file",
+      path = "example_test.exs",
+      range = { 1, 2 },
+    }
+
+    local actual_tbl =
+      core.build_mix_command(position, mix_task_func, extra_formatter_func, mix_task_args_func, {}, relative_to)
+
+    local expected = string.format(
+      "elixir -r %s -r %s -S mix test --formatter NeotestElixir.Formatter --formatter ExUnit.CLIFormatter example_test.exs",
+      core.json_encoder_path,
+      core.exunit_formatter_path
+    )
+    assert.are.equal(expected, table.concat(actual_tbl, " "))
+  end)
+end)


### PR DESCRIPTION
Fixes #12 
Closes #14 

Hi, @jfpedroza , It's super fast and works very well(single test, test file, test folder, whole project, and so on). You can test it with 

```
neotest.setup_project(vim.loop.cwd(), {
	adapters = { require("neotest-elixir") },
	default_strategy = "iex",
})
```

The core idea is: 

1. Check if there is an IEx shell terminal; if not, then create one and run the start command
2. Send the `IExUnit.run` and `ExUnit.configure(output: output, seed: seed)` to the IEx shell
3. use `tail -f | grep` to watch the results.

The caller code is here: https://github.com/jfpedroza/neotest-elixir/blob/dc6eb4502916a69ac67554516facf38f0f04d919/lua/neotest-elixir/init.lua#L191-L197

I also refactored the build_spec code and added tests because that part of the code was a bit confusing when stacked together.


## Preview


**With neotest command**

https://user-images.githubusercontent.com/12830256/222431631-243135d3-2389-446e-8f49-80416f35af43.mp4


**With test tree**

https://user-images.githubusercontent.com/12830256/222431378-eee1372e-8629-4d18-9a3e-961c1b87362c.mp4

### Knowing issues:

* **Compile file errors: **When there is a compilation error, the floating window takes longer(almost 1 second) to appear, which I suspect is caused by the integrated strategy module. Also, the content displayed is not complete.
  
    <img width="1041" alt="image" src="https://user-images.githubusercontent.com/12830256/222661746-03931a31-a329-4ee0-989a-2e842d5abd4e.png">

link: #12