### PR TITLE
feat: Specify full path for umbrella projects

### DIFF
--- a/lua/neotest-elixir/core.lua
+++ b/lua/neotest-elixir/core.lua
@@ -3,8 +3,21 @@ local Path = require("plenary.path")
 
 local M = {}
 
+function M.mix_root(file_path)
+  local root = lib.files.match_root_pattern("mix.exs")(file_path)
+
+  -- If the path found is inside an umbrella, return the root of the umbrella
+  if root ~= nil and root:match("/apps/[%w_]+$") then
+    local new_root = lib.files.match_root_pattern("mix.exs")(root:gsub("/apps/[%w_]+$", ""))
+
+    return new_root or root
+  end
+
+  return root
+end
+
 local function relative_to_cwd(path)
-  local root = lib.files.match_root_pattern("mix.exs")(path)
+  local root = M.mix_root(path)
   return Path:new(path):make_relative(root)
 end
 

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -40,12 +40,8 @@ local function post_process_command(cmd)
   return cmd
 end
 
-local function mix_root(file_path)
-  return lib.files.match_root_pattern("mix.exs")(file_path)
-end
-
 local function get_relative_path(file_path)
-  local mix_root_path = mix_root(file_path)
+  local mix_root_path = core.mix_root(file_path)
   local root_elems = vim.split(mix_root_path, Path.path.sep)
   local elems = vim.split(file_path, Path.path.sep)
   return table.concat({ unpack(elems, (#root_elems + 1), #elems) }, Path.path.sep)
@@ -70,7 +66,7 @@ function ElixirNeotestAdapter._generate_id(position, parents)
   end
 end
 
-ElixirNeotestAdapter.root = lib.files.match_root_pattern("mix.exs")
+ElixirNeotestAdapter.root = core.mix_root
 
 function ElixirNeotestAdapter.filter_dir(_, rel_path, _)
   return rel_path == "test"


### PR DESCRIPTION
Closes #18

Hey @scottming, I'm implementing #18 to remove the warning about umbrella projects. I noticed for IEx you do a `cd apps/child_app`. Was that only for the warning, or does IExUnit require running in the child app? To know if we can remove the cd or not.

cc @fuelen, if you want to try this before merging.