### PR TITLE
Do not use deprecated vim.tbl_flatten()

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ require("neotest").setup({
       -- Must be a function that receives the mix command as a table, to return a dynamic value
       -- Default: function(cmd) return cmd end
       post_process_command = function(cmd)
-        return vim.tbl_flatten({{"env", "FOO=bar"}, cmd})
+        return vim.iter({{"env", "FOO=bar"}, cmd}):flatten():totable()
       end,
       -- Delays writes so that results are updated at most every given milliseconds
       -- Decreasing this number improves snappiness at the cost of performance

--- a/lua/neotest-elixir/core.lua
+++ b/lua/neotest-elixir/core.lua
@@ -123,34 +123,37 @@ local function options_for_task(mix_task)
 end
 
 function M.build_mix_command(
-  position,
-  mix_task_func,
-  extra_formatters_func,
-  mix_task_args_func,
-  neotest_args,
-  relative_to_func
+    position,
+    mix_task_func,
+    extra_formatters_func,
+    mix_task_args_func,
+    neotest_args,
+    relative_to_func
 )
-  return vim.tbl_flatten({
-    {
-      "elixir",
-    },
-    -- deferent tasks have different options
-    -- for example, `test.interactive` needs to load a custom runner
-    options_for_task(mix_task_func()),
-    {
-      "-S",
-      "mix",
-      mix_task_func(), -- `test` is default
-    },
-    -- default is ExUnit.CLIFormatter
-    build_formatters(extra_formatters_func()),
-    -- default is {}
-    -- maybe `test.interactive` has different args with `test`
-    mix_task_args_func(),
-    neotest_args.extra_args or {},
-    -- test file or directory or testfile:line
-    test_target(position, relative_to_func),
-  })
+  return vim
+      .iter({
+        {
+          "elixir",
+        },
+        -- deferent tasks have different options
+        -- for example, `test.interactive` needs to load a custom runner
+        options_for_task(mix_task_func()),
+        {
+          "-S",
+          "mix",
+          mix_task_func(), -- `test` is default
+        },
+        -- default is ExUnit.CLIFormatter
+        build_formatters(extra_formatters_func()),
+        -- default is {}
+        -- maybe `test.interactive` has different args with `test`
+        mix_task_args_func(),
+        neotest_args.extra_args or {},
+        -- test file or directory or testfile:line
+        test_target(position, relative_to_func),
+      })
+      :flatten()
+      :totable()
 end
 
 -- public only for testing

--- a/lua/neotest-elixir/core.lua
+++ b/lua/neotest-elixir/core.lua
@@ -123,37 +123,37 @@ local function options_for_task(mix_task)
 end
 
 function M.build_mix_command(
-    position,
-    mix_task_func,
-    extra_formatters_func,
-    mix_task_args_func,
-    neotest_args,
-    relative_to_func
+  position,
+  mix_task_func,
+  extra_formatters_func,
+  mix_task_args_func,
+  neotest_args,
+  relative_to_func
 )
   return vim
-      .iter({
-        {
-          "elixir",
-        },
-        -- deferent tasks have different options
-        -- for example, `test.interactive` needs to load a custom runner
-        options_for_task(mix_task_func()),
-        {
-          "-S",
-          "mix",
-          mix_task_func(), -- `test` is default
-        },
-        -- default is ExUnit.CLIFormatter
-        build_formatters(extra_formatters_func()),
-        -- default is {}
-        -- maybe `test.interactive` has different args with `test`
-        mix_task_args_func(),
-        neotest_args.extra_args or {},
-        -- test file or directory or testfile:line
-        test_target(position, relative_to_func),
-      })
-      :flatten()
-      :totable()
+    .iter({
+      {
+        "elixir",
+      },
+      -- deferent tasks have different options
+      -- for example, `test.interactive` needs to load a custom runner
+      options_for_task(mix_task_func()),
+      {
+        "-S",
+        "mix",
+        mix_task_func(), -- `test` is default
+      },
+      -- default is ExUnit.CLIFormatter
+      build_formatters(extra_formatters_func()),
+      -- default is {}
+      -- maybe `test.interactive` has different args with `test`
+      mix_task_args_func(),
+      neotest_args.extra_args or {},
+      -- test file or directory or testfile:line
+      test_target(position, relative_to_func),
+    })
+    :flatten()
+    :totable()
 end
 
 -- public only for testing

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -54,13 +54,16 @@ function ElixirNeotestAdapter._generate_id(position, parents)
     return (relative_path .. ":" .. line_num)
   else
     return table.concat(
-      vim.tbl_flatten({
+      vim
+      .iter({
         position.path,
         vim.tbl_map(function(pos)
           return pos.name
         end, parents),
         position.name,
-      }),
+      })
+      :flatten()
+      :totable(),
       "::"
     )
   end
@@ -70,10 +73,10 @@ ElixirNeotestAdapter.root = core.mix_root
 
 function ElixirNeotestAdapter.filter_dir(_, rel_path, _)
   return rel_path == "test"
-    or vim.startswith(rel_path, "test/")
-    or rel_path == "apps"
-    or rel_path:match("^apps/[^/]+$")
-    or rel_path:match("^apps/[^/]+/test")
+      or vim.startswith(rel_path, "test/")
+      or rel_path == "apps"
+      or rel_path:match("^apps/[^/]+$")
+      or rel_path:match("^apps/[^/]+/test")
 end
 
 function ElixirNeotestAdapter.is_test_file(file_path)
@@ -175,7 +178,8 @@ end
 ---@async
 ---@return neotest.Tree | nil
 function ElixirNeotestAdapter.discover_positions(path)
-  local test_block_id_list = vim.tbl_flatten({ { "test", "feature", "property" }, get_extra_block_identifiers() })
+  local test_block_id_list =
+      vim.iter({ { "test", "feature", "property" }, get_extra_block_identifiers() }):flatten():totable()
   for index, value in ipairs(test_block_id_list) do
     test_block_id_list[index] = '"' .. value .. '"'
   end

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -55,15 +55,15 @@ function ElixirNeotestAdapter._generate_id(position, parents)
   else
     return table.concat(
       vim
-      .iter({
-        position.path,
-        vim.tbl_map(function(pos)
-          return pos.name
-        end, parents),
-        position.name,
-      })
-      :flatten()
-      :totable(),
+        .iter({
+          position.path,
+          vim.tbl_map(function(pos)
+            return pos.name
+          end, parents),
+          position.name,
+        })
+        :flatten()
+        :totable(),
       "::"
     )
   end
@@ -73,10 +73,10 @@ ElixirNeotestAdapter.root = core.mix_root
 
 function ElixirNeotestAdapter.filter_dir(_, rel_path, _)
   return rel_path == "test"
-      or vim.startswith(rel_path, "test/")
-      or rel_path == "apps"
-      or rel_path:match("^apps/[^/]+$")
-      or rel_path:match("^apps/[^/]+/test")
+    or vim.startswith(rel_path, "test/")
+    or rel_path == "apps"
+    or rel_path:match("^apps/[^/]+$")
+    or rel_path:match("^apps/[^/]+/test")
 end
 
 function ElixirNeotestAdapter.is_test_file(file_path)
@@ -179,7 +179,7 @@ end
 ---@return neotest.Tree | nil
 function ElixirNeotestAdapter.discover_positions(path)
   local test_block_id_list =
-      vim.iter({ { "test", "feature", "property" }, get_extra_block_identifiers() }):flatten():totable()
+    vim.iter({ { "test", "feature", "property" }, get_extra_block_identifiers() }):flatten():totable()
   for index, value in ipairs(test_block_id_list) do
     test_block_id_list[index] = '"' .. value .. '"'
   end


### PR DESCRIPTION
Replaces `vim.tbl_flatten({...})` with `vim.iter({...}):flatten():totable()`
