### PR TITLE
feat: Allow configuration of test directories and test file pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ require("neotest").setup({
       -- Can be a function to return a dynamic value.
       -- Default: 1000
       write_delay = 1000,
+      -- The pattern to match test files
+      -- Default: "_test.exs$"
+      test_file_pattern = ".test.exs$",
+      -- Function to determine whether a directory should be ignored
+      -- By default includes root test directory and umbrella apps' test directories
+      -- Params:
+      -- - name (string) - Name of directory
+      -- - rel_path (string) - Path to directory, relative to root
+      -- - root (string) - Root directory of project
+      filter_dir = function(name, rel_path, root)
+        return rel_path == "test"
+            or rel_path == "lib"
+            or vim.startswith(rel_path, 'test/')
+            or vim.startswith(rel_path, 'lib/')
+      end,
     }),
   }
 })

--- a/lua/neotest-elixir/base.lua
+++ b/lua/neotest-elixir/base.lua
@@ -1,7 +1,7 @@
 local M = {}
 
-function M.is_test_file(file_path)
-  return vim.endswith(file_path, "_test.exs")
+function M.is_test_file(file_path, pattern)
+  return file_path:match(pattern)
 end
 
 return M

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -344,7 +344,7 @@ end
 
 setmetatable(ElixirNeotestAdapter, {
   __call = function(_, opts)
-    if opts.post_process_command and type(opts.post_process_command) == "function" then
+    if is_callable(opts.post_process_command) then
       post_process_command = opts.post_process_command
     end
 
@@ -383,9 +383,8 @@ setmetatable(ElixirNeotestAdapter, {
       get_test_file_pattern = test_file_pattern
     end
 
-    local filter_dir_fn = callable_opt(opts.filter_dir)
-    if filter_dir_fn then
-      filter_dir = filter_dir_fn
+    if is_callable(opts.filter_dir) then
+      filter_dir = opts.filter_dir
     end
 
     return ElixirNeotestAdapter

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -36,6 +36,18 @@ local function get_iex_shell_direction()
   return "horizontal"
 end
 
+local function get_test_file_pattern()
+  return "_test.exs$"
+end
+
+local function filter_dir(_, rel_path, _)
+  return rel_path == "test"
+    or vim.startswith(rel_path, "test/")
+    or rel_path == "apps"
+    or rel_path:match("^apps/[^/]+$")
+    or rel_path:match("^apps/[^/]+/test")
+end
+
 local function post_process_command(cmd)
   return cmd
 end
@@ -68,16 +80,12 @@ end
 
 ElixirNeotestAdapter.root = core.mix_root
 
-function ElixirNeotestAdapter.filter_dir(_, rel_path, _)
-  return rel_path == "test"
-    or vim.startswith(rel_path, "test/")
-    or rel_path == "apps"
-    or rel_path:match("^apps/[^/]+$")
-    or rel_path:match("^apps/[^/]+/test")
+function ElixirNeotestAdapter.filter_dir(name, rel_path, root)
+  return filter_dir(name, rel_path, root)
 end
 
 function ElixirNeotestAdapter.is_test_file(file_path)
-  return base.is_test_file(file_path)
+  return base.is_test_file(file_path, get_test_file_pattern())
 end
 
 local function get_match_type(captured_nodes)
@@ -368,6 +376,16 @@ setmetatable(ElixirNeotestAdapter, {
     local write_delay = callable_opt(opts.write_delay)
     if write_delay then
       get_write_delay = write_delay
+    end
+
+    local test_file_pattern = callable_opt(opts.test_file_pattern)
+    if test_file_pattern then
+      get_test_file_pattern = test_file_pattern
+    end
+
+    local filter_dir_fn = callable_opt(opts.filter_dir)
+    if filter_dir_fn then
+      filter_dir = filter_dir_fn
     end
 
     return ElixirNeotestAdapter


### PR DESCRIPTION
In my project I keep test files in `lib/` directory next to the code with `*.test.exs` file names. This pretty much prevented me from using the plug-in in its current state so I made a couple little changes and gathered in this PR.

- expose `filter_dir` from neotest API directly to config (had no better idea but open to suggestions)
- add `test_file_pattern` option