### PR TITLE
fix: handle quoted test names

### DIFF
--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -133,6 +133,10 @@ local function clean_name(name)
     name = name:gsub('^"', ""):gsub('"$', "")
   end
 
+  -- Replace escaped quotes with literal quotes
+  name = name:gsub('\\"', '"')
+
+
   if vim.startswith(name, "\n  ") then
     name = remove_heredoc_prefix(name:sub(2))
   end

--- a/lua/neotest-elixir/init.lua
+++ b/lua/neotest-elixir/init.lua
@@ -136,7 +136,6 @@ local function clean_name(name)
   -- Replace escaped quotes with literal quotes
   name = name:gsub('\\"', '"')
 
-
   if vim.startswith(name, "\n  ") then
     name = remove_heredoc_prefix(name:sub(2))
   end

--- a/tests/sample_proj/test/sample_proj/parse_test.exs
+++ b/tests/sample_proj/test/sample_proj/parse_test.exs
@@ -35,6 +35,10 @@ defmodule SampleProj.ParseTest do
       assert SampleProj.hello() == :world
     end
 
+    test "with a \"quoted text\"" do
+      assert SampleProj.hello() == :world
+    end
+
     test "multiline
       test" do
       assert SampleProj.hello() == :world


### PR DESCRIPTION
Resolves https://github.com/jfpedroza/neotest-elixir/issues/45. I'm not 100% sure why, but it seems like lua is interpreting the Elixir escape sequence `\"` as literally backslash single quote instead of considering it as an escape sequence. Replacing the escaped quote with a literal quote fixes this 